### PR TITLE
Fixing

### DIFF
--- a/models/ModelBase.py
+++ b/models/ModelBase.py
@@ -10,9 +10,7 @@ import datetime
 from pathlib import Path
 import yaml
 from jsonschema import validate, ValidationError
-import models
 
-import cv2
 import numpy as np
 
 from core import imagelib, pathex
@@ -519,10 +517,10 @@ class ModelBase(object):
         if key in nested_dict:
             nested_dict[key] = self.__convert_type_write(val)
             return True
-        for k, v in nested_dict.items():
-              if isinstance(v, dict):
-                  if self.__update_nested_dict(v, key, val):
-                      return True
+        for v in nested_dict.values():
+            if isinstance(v, dict):
+                if self.__update_nested_dict(v, key, val):
+                    return True
         return False
 
     def __iterate_read_dict(self, nested_dict, new_dict=None):
@@ -571,12 +569,11 @@ class ModelBase(object):
         Args:
             filepath (str|Path): Path where to save configuration file.
         """
-
         formatted_dict = self.read_from_config_file(self.get_formatted_configuration_path(), keep_nested=True, validation=False)
 
         for key, value in self.options.items():
             if not self.__update_nested_dict(formatted_dict, key, value):
-                formatted_dict[key] = self.__convert_type_write(value)
+                print(f"'{key}' not saved in the configuration file")
 
         try:
             with open(filepath, 'w') as file:

--- a/models/Model_AMP/Model.py
+++ b/models/Model_AMP/Model.py
@@ -31,8 +31,16 @@ class AMPModel(ModelBase):
         default_d_mask_dims        = self.options['d_mask_dims']        = self.options.get('d_mask_dims', None)
         default_morph_factor       = self.options['morph_factor']       = self.load_or_def_option('morph_factor', 0.5)
         default_masked_training    = self.options['masked_training']    = self.load_or_def_option('masked_training', True)
+        
         default_eyes_prio          = self.options['eyes_prio']          = self.load_or_def_option('eyes_prio', False)
         default_mouth_prio         = self.options['mouth_prio']         = self.load_or_def_option('mouth_prio', False)
+
+        # Compatibility check
+        eyes_mouth_prio = self.options.get('eyes_mouth_prio')
+        if eyes_mouth_prio is not None:
+            default_eyes_prio = self.options['eyes_prio'] = eyes_mouth_prio
+            default_mouth_prio = self.options['mouth_prio'] = eyes_mouth_prio
+
         default_uniform_yaw        = self.options['uniform_yaw']        = self.load_or_def_option('uniform_yaw', False)
 
         # Uncomment it just if you want to impelement other loss functions

--- a/models/Model_AMP/formatted_config.yaml
+++ b/models/Model_AMP/formatted_config.yaml
@@ -30,7 +30,6 @@ model_properties:
   background_power: 0.0
   face_style_power: 0.0
   bg_style_power: 0.0
-  eyes_mouth_prio: false
   cpu_cap: 8
   preview_samples: 4
   force_full_preview: false

--- a/models/Model_SAEHD/Model.py
+++ b/models/Model_SAEHD/Model.py
@@ -43,8 +43,16 @@ class SAEHDModel(ModelBase):
         default_d_dims             = self.options['d_dims']             = self.options.get('d_dims', None)
         default_d_mask_dims        = self.options['d_mask_dims']        = self.options.get('d_mask_dims', None)
         default_masked_training    = self.options['masked_training']    = self.load_or_def_option('masked_training', True)
+
         default_eyes_prio          = self.options['eyes_prio']          = self.load_or_def_option('eyes_prio', False)
         default_mouth_prio         = self.options['mouth_prio']         = self.load_or_def_option('mouth_prio', False)
+
+        # Compatibility check
+        eyes_mouth_prio = self.options.get('eyes_mouth_prio')
+        if eyes_mouth_prio is not None:
+            default_eyes_prio = self.options['eyes_prio'] = eyes_mouth_prio
+            default_mouth_prio = self.options['mouth_prio'] = eyes_mouth_prio
+
         default_uniform_yaw        = self.options['uniform_yaw']        = self.load_or_def_option('uniform_yaw', False)
         default_blur_out_mask      = self.options['blur_out_mask']      = self.load_or_def_option('blur_out_mask', False)
 

--- a/models/Model_SAEHD/formatted_config.yaml
+++ b/models/Model_SAEHD/formatted_config.yaml
@@ -31,7 +31,6 @@ model_properties:
   true_face_power: 0.0
   face_style_power: 0.0
   bg_style_power: 0.0
-  eyes_mouth_prio: false
   cpu_cap: 8
   preview_samples: 4
   force_full_preview: false


### PR DESCRIPTION
- Deleted eyes_mouth_prio keyword from formatted_config files because
  this option doesn't exist in the MVE fork.
- Added a compatibility check to enable both eyes prio and mouth prio if
  eyes_mouth_prio keyword is found in the options.
- Now options not present in the 'formatted_config' file will not be
  saved in the generated configuration file.