### PR TITLE
Improve background training when masked training is enabled

### DIFF
--- a/models/Model_AMP/Model.py
+++ b/models/Model_AMP/Model.py
@@ -644,8 +644,11 @@ class AMPModel(ModelBase):
                     gpu_dst_losses += [gpu_dst_loss]
                     gpu_G_loss = gpu_src_loss + gpu_dst_loss
                     # dst-dst background weak loss
-                    gpu_G_loss += tf.reduce_mean(0.1*tf.square(gpu_pred_dst_dst_anti_masked-gpu_target_dst_anti_masked),axis=[1,2,3] )
-                    gpu_G_loss += 0.000001*nn.total_variation_mse(gpu_pred_dst_dst_anti_masked)
+                    gpu_G_loss += tf.reduce_mean(25*tf.square(gpu_pred_dst_dst_anti_masked-gpu_target_dst_anti_masked),axis=[1,2,3] )
+                    gpu_G_loss += 0.00001*nn.total_variation_mse(gpu_pred_dst_dst_anti_masked)
+                    # src-src background weak loss
+                    gpu_G_loss += tf.reduce_mean(25*tf.square(gpu_pred_src_src_anti_masked-gpu_target_src_anti_masked),axis=[1,2,3] )
+                    gpu_G_loss += 0.00001*nn.total_variation_mse(gpu_pred_src_src_anti_masked)
 
 
                     if gan_power != 0:


### PR DESCRIPTION
Improves background of source and destination so it doesn't grey out when using masked training. It doesn't and should not affect current loss value, or reduce training speed.
![_last](https://github.com/MachineEditor/DeepFaceLab/assets/59157319/574194c1-6ec8-4682-8666-b7eb44ed16d5)
