### PR TITLE
Payuyi cc-aug color augmentation option for AMP (possibly experimental)

### DIFF
--- a/core/imagelib/__init__.py
+++ b/core/imagelib/__init__.py
@@ -12,7 +12,7 @@ from .warp import gen_warp_params, warp_by_params
 
 from .reduce_colors import reduce_colors
 
-from .color_transfer import color_transfer, color_transfer_mix, color_transfer_sot, color_transfer_mkl, color_transfer_idt, color_hist_match, reinhard_color_transfer, linear_color_transfer, color_augmentation 
+from .color_transfer import color_transfer, cc_aug, color_transfer_mix, color_transfer_sot, color_transfer_mkl, color_transfer_idt, color_hist_match, reinhard_color_transfer, linear_color_transfer, color_augmentation 
 
 from .common import random_crop, normalize_channels, cut_odd_image, overlay_alpha_image
 

--- a/models/Model_AMP/Model.py
+++ b/models/Model_AMP/Model.py
@@ -218,7 +218,7 @@ class AMPModel(ModelBase):
                 self.options['background_power'] = np.clip ( io.input_number("Background power", default_background_power, add_info="0.0..1.0", help_message="Learn the area outside of the mask. Helps smooth out area near the mask boundaries. Can be used at any time"), 0.0, 1.0 )
 
 
-                self.options['ct_mode'] = io.input_str (f"Color transfer for src faceset", default_ct_mode, ['none','rct','lct','mkl','idt','sot', 'fs-aug'], help_message="Change color distribution of src samples close to dst samples. Try all modes to find the best.")
+                self.options['ct_mode'] = io.input_str (f"Color transfer for src faceset", default_ct_mode, ['none','rct','lct','mkl','idt','sot', 'fs-aug', 'cc-aug'], help_message="Change color distribution of src samples close to dst samples. Try all modes to find the best.")
                 self.options['random_color'] = io.input_bool ("Random color", default_random_color, help_message="Samples are randomly rotated around the L axis in LAB colorspace, helps generalize training")
 
                 self.options['clipgrad'] = io.input_bool ("Enable gradient clipping", default_clipgrad, help_message="Gradient clipping reduces chance of model collapse, sacrificing speed of training.")
@@ -829,7 +829,10 @@ class AMPModel(ModelBase):
             fs_aug = None
             if ct_mode == 'fs-aug':
                 fs_aug = 'fs-aug'
-
+            cc_aug= None
+            if ct_mode == 'cc-aug':
+                cc_aug = 'cc-aug'
+                
             channel_type = SampleProcessor.ChannelType.LAB_RAND_TRANSFORM if self.options['random_color'] else SampleProcessor.ChannelType.BGR
 
             # Check for pak names
@@ -876,9 +879,9 @@ class AMPModel(ModelBase):
                                                  'random_blur': self.options['random_blur'],
                                                  'random_jpeg': self.options['random_jpeg'],
                                                  'random_shadow': random_shadow_dst,
-                                                 'transform':True, 'channel_type' : channel_type, 'ct_mode': fs_aug,
+                                                 'transform':True, 'channel_type' : channel_type, 'ct_mode': fs_aug, 'ct_mode': cc_aug,
                                                  'face_type':self.face_type, 'data_format':nn.data_format, 'resolution': resolution},
-                                                {'sample_type': SampleProcessor.SampleType.FACE_IMAGE,'warp':False                      , 'transform':True, 'channel_type' : channel_type, 'ct_mode': fs_aug, 'random_shadow': random_shadow_dst,   'face_type':self.face_type, 'data_format':nn.data_format, 'resolution': resolution},
+                                                {'sample_type': SampleProcessor.SampleType.FACE_IMAGE,'warp':False                      , 'transform':True, 'channel_type' : channel_type, 'ct_mode': fs_aug, 'ct_mode': cc_aug, 'random_shadow': random_shadow_dst,   'face_type':self.face_type, 'data_format':nn.data_format, 'resolution': resolution},
                                                 {'sample_type': SampleProcessor.SampleType.FACE_MASK, 'warp':False                      , 'transform':True, 'channel_type' : SampleProcessor.ChannelType.G,   'face_mask_type' : SampleProcessor.FaceMaskType.FULL_FACE, 'face_type':self.face_type, 'data_format':nn.data_format, 'resolution': resolution},
                                                 {'sample_type': SampleProcessor.SampleType.FACE_MASK, 'warp':False                      , 'transform':True, 'channel_type' : SampleProcessor.ChannelType.G,   'face_mask_type' : SampleProcessor.FaceMaskType.FULL_FACE_EYES, 'face_type':self.face_type, 'data_format':nn.data_format, 'resolution': resolution},
                                               ],

--- a/models/Model_AMP/config_schema.json
+++ b/models/Model_AMP/config_schema.json
@@ -188,7 +188,8 @@
             "mkl",
             "idt",
             "sot",
-            "fs-aug"
+            "fs-aug",
+            "cc-aug"
           ]
         },
         "random_color": {

--- a/samplelib/SampleProcessor.py
+++ b/samplelib/SampleProcessor.py
@@ -194,9 +194,11 @@ class SampleProcessor(object):
                                 img = cv2.resize( img, (resolution, resolution), interpolation=cv2.INTER_CUBIC )
 
                         # Apply random color transfer
-                        if ct_mode is not None and ct_sample is not None or ct_mode == 'fs-aug':
+                        if ct_mode is not None and (ct_sample is not None or ct_mode == 'fs-aug' or ct_mode == 'cc-aug'):
                             if ct_mode == 'fs-aug':
                                 img = imagelib.color_augmentation(img, sample_rnd_seed)
+                            if ct_mode == 'cc-aug':
+                                img = imagelib.cc_aug(img, sample_rnd_seed)
                             else:
                                 if ct_sample_bgr is None:
                                     ct_sample_bgr = ct_sample.load_bgr()


### PR DESCRIPTION
This color augmentation functions similar to fs-aug and random color but should be a standalone one meaning it should only be used as is without any other (fs-aug, random color). This should sort of combine fs-aug and random color but reduce the possible gradient collapses that are rare but can occur with previous color augs, also increases the range of brightness contrast and saturation and hopefully the ability for the model to match lighting/color conditions of the destination face in a more proper way.
![Training preview2](https://github.com/MachineEditor/DeepFaceLab/assets/59157319/db6c190b-b973-4ba9-b4dc-956737bd2823)
